### PR TITLE
Set resource ID as id instead of managerlog

### DIFF
--- a/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
+++ b/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
@@ -114,7 +114,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
             'text' => $this->modx->lexicon('resource_overview'),
             'params' => [
                 'a' => 'resource/data',
-                'id' => $object->get('id'),
+                'id' => $object->get('item'),
                 'type' => 'view',
             ],
         ];
@@ -123,7 +123,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
                 'text' => $this->modx->lexicon('resource_edit'),
                 'params' => [
                     'a' => 'resource/update',
-                    'id' => $object->get('id'),
+                    'id' => $object->get('item'),
                     'type' => 'edit',
                 ],
             ];
@@ -132,7 +132,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
         $row['menu'][] = [
             'text' => $this->modx->lexicon('resource_preview'),
             'params' => [
-                'url' => $this->modx->makeUrl($object->get('id'), null, '', 'full'),
+                'url' => $this->modx->makeUrl($object->get('item'), null, '', 'full'),
                 'type' => 'open',
             ],
             'handler' => 'this.preview',


### PR DESCRIPTION
### What does it do?
Enables users to go to the page when using the buttons in the widget

### Why is it needed?
Used to be going to an error page
