### PR TITLE
Add xPDOQueryCondition

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -36,6 +36,7 @@ class_alias('xPDO\xPDO', 'xPDO');
 class_alias('\xPDO\Om\xPDOCriteria', 'xPDOCriteria');
 class_alias('\xPDO\Om\xPDOSimpleObject', 'xPDOSimpleObject');
 class_alias('\xPDO\Om\xPDOQuery', 'xPDOQuery');
+class_alias('\xPDO\Om\xPDOQueryCondition', 'xPDOQueryCondition');
 class_alias('\xPDO\Om\xPDOObject', 'xPDOObject');
 class_alias('\xPDO\Cache\xPDOCacheManager', 'xPDOCacheManager');
 class_alias('\xPDO\Cache\xPDOFileCache', 'xPDOFileCache');


### PR DESCRIPTION
Add 
`class_alias('\xPDO\Om\xPDOQueryCondition', 'xPDOQueryCondition');`
Because some packages (for example Minishop2 ) use it

### What does it do?
Fix xPDOQueryCondition in some old packages 

### Why is it needed?
If U want to use Minishop2 on Modx3

