### PR TITLE
Changed order of array_merge to have the mediasource value to remain.…

### DIFF
--- a/core/model/modx/sources/modmediasource.class.php
+++ b/core/model/modx/sources/modmediasource.class.php
@@ -1324,7 +1324,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             }
             $list[$property['name']] = $value;
         }
-        $list = array_merge($list, $this->properties);
+        $list = array_merge($this->properties, $list);
 
         return $list;
     }


### PR DESCRIPTION
… Fixes #14604

### What does it do?
Reverse the array_merge order in order to maintain the mediasource properties.

### Why is it needed?
It resolves the issue where allowedFileTypes was ignored.

### Related issue(s)/PR(s)
#14604 
