### PR TITLE
Fix image rotate in MediaBrowser

### DIFF
--- a/core/model/modx/sources/modmediasource.class.php
+++ b/core/model/modx/sources/modmediasource.class.php
@@ -2181,6 +2181,23 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             } catch (Exception $E) {
                 $timestamp = 0;
             }
+
+            if ($bases['pathIsRelative']) {
+                $absolute_path = $bases['pathAbsolute'] . $path;
+            } else {
+                $absolute_path = $path;
+            }
+            if (function_exists('exif_read_data')) {
+                $exif = @exif_read_data($absolute_path);
+                if (!empty($exif) && $exif['Orientation'] >= 5) {
+                    // This image was rotated
+                    $new_width = $size['height'];
+                    $new_height = $size['width'];
+                    $size['width'] = $new_width;
+                    $size['height'] = $new_height;
+                }
+            }
+
             // get original image size for proportional scaling
             if ($size['width'] > $size['height']) {
                 // landscape
@@ -2206,6 +2223,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 'wctx' => $this->ctx->get('key'),
                 'source' => $this->get('id'),
                 't' => $timestamp,
+                'ar' => 'x'
             ]);
             $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL) . 'system/phpthumb.php?' . $imageQuery;
         }


### PR DESCRIPTION
Before
![222](https://user-images.githubusercontent.com/4846064/119637827-bc288300-be1e-11eb-8c92-76feeb864a9c.jpg)

After fix
![3333](https://user-images.githubusercontent.com/4846064/119637831-bd59b000-be1e-11eb-9670-253c1d12c56f.jpg)

### What does it do?
Fix Image rotate

### Why is it needed?
Fix incorrect image rotate

### How to test
Upload incorrect image and check in MediaBrowser

Thx to Iliya Utkon (fix in modx3)

 
