### PR TITLE
Fix allowedFileTypes

### DIFF
--- a/core/model/modx/sources/modmediasource.class.php
+++ b/core/model/modx/sources/modmediasource.class.php
@@ -1973,7 +1973,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
      */
     protected function getAllowedExtensionsArray($properties = [])
     {
-        $allowedExtensions = $this->getOption('allowedFileTypes', $properties, '');
+        $allowedExtensions = $this->getOption('allowedFileTypes', $this->properties, '');
         if (is_string($allowedExtensions)) {
             if (empty($allowedExtensions)) {
                 $allowedExtensions = [];


### PR DESCRIPTION
```
$allowedExtensions = $this->getOption('allowedFileTypes', $properties, ''); - return NULL 
$allowedExtensions = $this->getOption('allowedFileTypes', $this->properties, ''); - return correct value 
```

### What does it do?
Fix this bug [youtube.com](https://www.youtube.com/watch?v=ua4xgooLTm4
)

### Why is it needed?
To fix allowedFileTypes bug

 