### PR TITLE
Fix overriding of source properties

### DIFF
--- a/core/model/modx/sources/modmediasource.class.php
+++ b/core/model/modx/sources/modmediasource.class.php
@@ -1319,6 +1319,9 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         $list = [];
         foreach ($properties as $property) {
             $value = $property['value'];
+            if (empty($value) && !empty($this->properties[$property['name']])) {
+                $value = $this->properties[$property['name']];
+            }
             if (!empty($property['xtype']) && $property['xtype'] == 'combo-boolean') {
                 $value = empty($property['value']) && $property['value'] != 'true' ? false : true;
             }


### PR DESCRIPTION
### What does it do?
This change will override empty values of media source when value is set in properties.

### Why is it needed?
Fix this bug https://www.youtube.com/watch?v=ua4xgooLTm4

### Related issue(s)/PR(s)
https://github.com/Sterc/revolution/pull/34
